### PR TITLE
rubyforge #28865 - expose sqlscale attribute of ResultSet and Row columns

### DIFF
--- a/ext/ResultSet.c
+++ b/ext/ResultSet.c
@@ -47,6 +47,7 @@ static VALUE getResultSetDialect(VALUE);
 static VALUE getResultSetColumnCount(VALUE);
 static VALUE getResultSetColumnName(VALUE, VALUE);
 static VALUE getResultSetColumnAlias(VALUE, VALUE);
+static VALUE getResultSetColumnScale(VALUE, VALUE);
 static VALUE getResultSetColumnTable(VALUE, VALUE);
 static VALUE getResultSetColumnType(VALUE, VALUE);
 static VALUE eachResultSetRow(VALUE);
@@ -507,6 +508,41 @@ static VALUE getResultSetColumnAlias(VALUE self, VALUE column)
    return(alias);
 }
 
+/**
+ * This function provides the column_scale method for the ResultSet class.
+ *
+ * @param  self    A reference to the ResultSet object to retrieve the column
+ *                 alias from.
+ * @param  column  An offset to the column to retrieve the scale of.
+ *
+ * @return  An Integer representing the sqlscale of the column, or nil if an
+ *          invalid column was specified.
+ *
+ */
+static VALUE getResultSetColumnScale(VALUE self, VALUE column)
+{
+	 VALUE         scale    = Qnil;
+   ResultsHandle *results = NULL;
+
+   Data_Get_Struct(self, ResultsHandle, results);
+   if(results != NULL)
+   {
+      int offset = 0;
+
+      offset = (TYPE(column) == T_FIXNUM ? FIX2INT(column) : NUM2INT(column));
+      if(offset >= 0 && offset < results->output->sqld)
+      {
+         XSQLVAR *var = results->output->sqlvar;
+         int     index;
+
+         for(index = 0; index < offset; index++, var++);
+         scale = INT2FIX(var->sqlscale);
+      }
+   }
+
+   return(scale);
+}
+
 
 /**
  * This function provides the column_table method for the ResultSet class.
@@ -803,6 +839,7 @@ void Init_ResultSet(VALUE module)
    rb_define_method(cResultSet, "each", eachResultSetRow, 0);
    rb_define_method(cResultSet, "column_name", getResultSetColumnName, 1);
    rb_define_method(cResultSet, "column_alias", getResultSetColumnAlias, 1);
+   rb_define_method(cResultSet, "column_scale", getResultSetColumnScale, 1);
    rb_define_method(cResultSet, "column_table", getResultSetColumnTable, 1);
    rb_define_method(cResultSet, "column_count", getResultSetColumnCount, 0);
    rb_define_method(cResultSet, "exhausted?", isResultSetExhausted, 0);

--- a/ext/Row.c
+++ b/ext/Row.c
@@ -36,6 +36,7 @@ static VALUE columnsInRow(VALUE);
 static VALUE getRowNumber(VALUE);
 static VALUE getColumnName(VALUE, VALUE);
 static VALUE getColumnAlias(VALUE, VALUE);
+static VALUE getColumnScale(VALUE, VALUE);
 static VALUE getColumnValue(VALUE, VALUE);
 static VALUE eachColumn(VALUE);
 static VALUE eachColumnKey(VALUE);
@@ -128,6 +129,7 @@ static VALUE initializeRow(VALUE self, VALUE results, VALUE data, VALUE number)
             VALUE index,
                   name,
                   alias,
+                  scale,
                   items;
                   
             index = INT2NUM(i);
@@ -138,6 +140,7 @@ static VALUE initializeRow(VALUE self, VALUE results, VALUE data, VALUE number)
             items = rb_ary_entry(data, i);
             row->columns[i].value = rb_ary_entry(items, 0);
             row->columns[i].type  = rb_ary_entry(items, 1);
+            row->columns[i].scale = rb_funcall(results, rb_intern("column_scale"), 1, index);
             
             if(TYPE(rb_ary_entry(items, 1)) == T_NIL)
             {
@@ -707,25 +710,65 @@ VALUE getColumnBaseType(VALUE self, VALUE index)
    if(TYPE(index) == T_FIXNUM)
    {
       RowHandle *row   = NULL;
-      
+
       Data_Get_Struct(self, RowHandle, row);
       if(row != NULL)
       {
          int offset = FIX2INT(index);
-         
+
          /* Correct negative index values. */
          if(offset < 0)
          {
             offset = row->size + offset;
          }
-         
+
          if(offset >= 0 && offset < row->size)
          {
             result = row->columns[offset].type;
          }
       }
    }
-   
+
+   return(result);
+}
+
+/**
+ * This function provides the column_scale method for the Row class.
+ *
+ * @param  self    A reference to the Row object to retrieve the column
+ *                 alias from.
+ * @param  column  An offset to the column to retrieve the scale of.
+ *
+ * @return  An Integer representing the scale of the column, or nil if an
+ *          invalid column was specified.
+ *
+ */
+static VALUE getColumnScale(VALUE self, VALUE index)
+{
+   VALUE result = Qnil;
+
+   if(TYPE(index) == T_FIXNUM)
+   {
+      RowHandle *row   = NULL;
+
+      Data_Get_Struct(self, RowHandle, row);
+      if(row != NULL)
+      {
+         int offset = FIX2INT(index);
+
+         /* Correct negative index values. */
+         if(offset < 0)
+         {
+            offset = row->size + offset;
+         }
+
+         if(offset >= 0 && offset < row->size)
+         {
+            result = row->columns[offset].scale;
+         }
+      }
+   }
+
    return(result);
 }
 
@@ -936,6 +979,7 @@ void Init_Row(VALUE module)
    rb_define_method(cRow, "column_count", columnsInRow, 0);
    rb_define_method(cRow, "column_name", getColumnName, 1);
    rb_define_method(cRow, "column_alias", getColumnAlias, 1);
+   rb_define_method(cRow, "column_scale", getColumnScale, 1);
    rb_define_method(cRow, "each", eachColumn, 0);
    rb_define_method(cRow, "each_key", eachColumnKey, 0);
    rb_define_method(cRow, "each_value", eachColumnValue, 0);

--- a/ext/Row.h
+++ b/ext/Row.h
@@ -37,7 +37,8 @@
       char  name[32],
             alias[32];
       VALUE value,
-            type;
+            type,
+            scale;
    } ColumnHandle;
    
    typedef struct

--- a/lib/src.rb
+++ b/lib/src.rb
@@ -773,6 +773,26 @@ module Rubyfb
       
       
       #
+      # This method fetches the scale associated with a specified column for a
+      # ResultSet object.  Firebird implements some floating point types with
+      # integral storage and a negative scale.  For example, depending on
+      # your platform
+      #
+      #    SELECT 1.003 FROM RDB$DATABASE
+      #
+      # may return a ResultSet, the first and only column of which has
+      # a base type of :BIGINT but a scale of -3.  (Fetches of the actual
+      # value will correctly return a ruby Float.)
+      #
+      # ==== Parameters
+      # column::  A reference to the column number to fetch the details for.
+      #           Column numbers start at zero.
+      #
+      def column_scale(column)
+      end
+
+
+      #
       # This method fetches the table name associated with a specified column
       # for a ResultSet object.
       #
@@ -909,6 +929,19 @@ module Rubyfb
       #          column in the row is at offset zero.
       #
       def column_alias(index)
+      end
+
+
+      #
+      # This method fetches the scale associated with a specified column
+      # within a row of data.  See the documentation of
+      # ResultSet#column_scale for details.
+      #
+      # ==== Parameters
+      # column::  A reference to the column number to fetch the details for.
+      #           Column numbers start at zero.
+      #
+      def column_scale(column)
       end
       
       

--- a/test/ResultSetTest.rb
+++ b/test/ResultSetTest.rb
@@ -159,4 +159,17 @@ class ResultSetTest < Test::Unit::TestCase
          results.close if results != nil
       end
    end
+   def test05
+      results = @transactions[0].execute(<<-EOSQL)
+                SELECT CAST(5.01 AS DECIMAL(6,5)) AS "COL01",
+                       2.2                        AS "COL02",
+                       CAST(3 AS INTEGER)         AS "COL03"
+                  FROM RDB$DATABASE
+                EOSQL
+      assert_equal(-5, results.column_scale(0))
+      assert_equal(-1, results.column_scale(1))
+      assert_equal(0, results.column_scale(2))
+   ensure
+      results.close if results
+   end
 end

--- a/test/RowTest.rb
+++ b/test/RowTest.rb
@@ -200,4 +200,20 @@ class RowTest < Test::Unit::TestCase
          results.close if results != nil
       end
    end
+
+   def test04
+      results = @transactions[0].execute(<<-EOSQL)
+                SELECT CAST(5.01 AS DECIMAL(6,5)) AS "COL01",
+                       2.2                        AS "COL02",
+                       CAST(3 AS INTEGER)         AS "COL03"
+                  FROM RDB$DATABASE
+                EOSQL
+      row     = results.fetch
+
+      assert_equal(-5, row.column_scale(0))
+      assert_equal(-1, row.column_scale(1))
+      assert_equal(0, row.column_scale(2))
+   ensure
+      results.close if results
+   end
 end


### PR DESCRIPTION
A column's _scale_ is needed to correctly distinguish &mdash; without fetching any rows &mdash; some integral columns from some floating point columns, since `#get_base_type` may return, for example `:BIGINT` in both cases.

See [rubyforge tracker #28865](http://rubyforge.org/tracker/index.php?func=detail&aid=28865&group_id=9658&atid=37371) for details.
