### PR TITLE
Make #fetch() *always* return nil if #exhausted?

### DIFF
--- a/ext/ResultSet.c
+++ b/ext/ResultSet.c
@@ -240,7 +240,7 @@ VALUE fetchResultSetEntry(VALUE self) {
              value;
 
   Data_Get_Struct(self, ResultsHandle, results);
-  if(results->handle != 0) {
+  if(results->handle != 0 && !results->exhausted) {
     VALUE array,number;
     value = results->procedure_output_fetch_state;
     if(value < 0) {
@@ -262,15 +262,6 @@ VALUE fetchResultSetEntry(VALUE self) {
       results->exhausted = 1;
       resolveResultsTransaction(results, "commit");
       break;
-    case isc_req_sync:
-      /* Return nil if #fetch() was called after we were #exhausted?.
-       * Otherwise, fall through to error.
-       *
-       * SQLCODE -901 request synchronization error (isc_req_sync)
-       * "Unsuccessful execution caused by system error that does not
-       * preclude successful execution of subsequent statements."
-       */
-      if (results->exhausted) break;
     default:
       rb_fireruby_raise(status, "Error fetching query row.");
     }

--- a/ext/ResultSet.c
+++ b/ext/ResultSet.c
@@ -262,6 +262,15 @@ VALUE fetchResultSetEntry(VALUE self) {
       results->exhausted = 1;
       resolveResultsTransaction(results, "commit");
       break;
+    case isc_req_sync:
+      /* Return nil if #fetch() was called after we were #exhausted?.
+       * Otherwise, fall through to error.
+       *
+       * SQLCODE -901 request synchronization error (isc_req_sync)
+       * "Unsuccessful execution caused by system error that does not
+       * preclude successful execution of subsequent statements."
+       */
+      if (results->exhausted) break;
     default:
       rb_fireruby_raise(status, "Error fetching query row.");
     }

--- a/test/ResultSetTest.rb
+++ b/test/ResultSetTest.rb
@@ -172,4 +172,17 @@ class ResultSetTest < Test::Unit::TestCase
    ensure
       results.close if results
    end
+
+   def test06
+      results = @transactions.first.execute(<<-EOSQL)
+                SELECT * FROM RDB$DATABASE WHERE 1=0
+                EOSQL
+
+      assert_nil(results.fetch,
+                 'Initial #fetch of empty result set was not nil')
+          assert(results.exhausted?,
+                 'Completely fetched ResultSet was not #exhausted?')
+      assert_nil(results.fetch,
+                 '#fetch after exhaustion was not nil')
+   end
 end


### PR DESCRIPTION
## Issue

Calling `#fetch` on an `#exhausted?` result set throws a Firebird "Request Synchronization Error," rather than repeatedly returning _nil_, as I'd expect from the documentation.
## How to reproduce

See new unit test added in this pull request.  Or, issue a SELECT, iterate with `#each()` or any Enumerable method on the ResultSet, and then call `#fetch()`.
## Proposed fixes

A few ways I can think of:
- Check `result->exhausted` before attempting a `isc_dsql_fetch`
  This is what this Pull Request implements.
- Ignore `isc_req_sync` errors thrown after an `isc_dsql_fetch` if we are exhausted.
  Implemented here: https://github.com/pilcrow/rubyfb/tree/exhausted-fetch
- Re-define the ResultSet's #fetch() method to return nil when we're exhausted.
