### PR TITLE
bugfix: do not close cursor for fetches returning FETCH_ONE

### DIFF
--- a/lib/rubyfb/result_set.rb
+++ b/lib/rubyfb/result_set.rb
@@ -35,7 +35,7 @@ module Rubyfb
         when Statement::FETCH_ONE
           @row_count = 1
           row = Row.new(statement.metadata, statement.current_row(transaction), @row_count)
-          close
+          @active = false
         else
           raise FireRubyException.new("Error fetching query row.");
       end if active?


### PR DESCRIPTION
when fetching results from a select clause with returning, cursor must not be closed as it is not used in this case.